### PR TITLE
Parallel ray proccessing using std threads

### DIFF
--- a/MIndices/AnglePair.h
+++ b/MIndices/AnglePair.h
@@ -16,8 +16,6 @@
 
 namespace MIndices
 {
-	constexpr int32_t ELEVATION = 90;
-	constexpr int32_t AZIMUTH = 180;
 
 	class AnglePair
 	{
@@ -25,6 +23,9 @@ namespace MIndices
 		AnglePair(int32_t a, int32_t e);
 		AnglePair(const AnglePair& other);
 		~AnglePair() = default;
+		AnglePair(AnglePair&&) = default;
+		AnglePair& operator=(AnglePair&&) = default;
+		AnglePair& operator=(const AnglePair& other) = default;
 
 		int32_t Azimuth() const;
 		int32_t Elevation() const;

--- a/MIndices/BVHNode.cpp
+++ b/MIndices/BVHNode.cpp
@@ -4,7 +4,7 @@
 
 using namespace MIndices;
 
-BVHNode::BVHNode(BoundingBox3D b, vector<Triangle> tri) : bbox(b), triangles(tri), right(nullptr), left(nullptr)
+BVHNode::BVHNode(BoundingBox3D b, std::vector<Triangle> tri) : bbox(b), triangles(tri), right(nullptr), left(nullptr)
 {
 }
 
@@ -31,7 +31,7 @@ BVHNode::~BVHNode()
 	}
 }
 
-bool HasEvenintersections(const vector<Triangle>& t)
+bool HasEvenintersections(const std::vector<Triangle>& t)
 {
 	if (t.size() % 2 == 0)
 	{
@@ -47,7 +47,7 @@ void BVHNode::SetBBox(const BoundingBox3D& newBBox)
 	bbox = newBBox;
 }
 
-void BVHNode::SetTriangles(const vector<Triangle>& triangles)
+void BVHNode::SetTriangles(const std::vector<Triangle>& triangles)
 {
 	this->triangles = triangles;
 }
@@ -96,12 +96,12 @@ const BoundingBox3D& BVHNode::Box() const noexcept
 	return bbox;
 }
 
-vector<Triangle> BVHNode::GetTriangles() const noexcept
+std::vector<Triangle> BVHNode::GetTriangles() const noexcept
 {
 	return triangles;
 }
 
-vector<TriangleEdge> BVHNode::GetEdges() const noexcept
+std::vector<TriangleEdge> BVHNode::GetEdges() const noexcept
 {
 	return edges;
 }

--- a/MIndices/BVHNode.h
+++ b/MIndices/BVHNode.h
@@ -5,15 +5,13 @@
 #include "Structures.h"
 #include <vector>
 
-using std::vector;
-
 namespace MIndices
 {
 
 	class BVHNode
 	{
 	public:
-		BVHNode(BoundingBox3D bbox, vector<Triangle> triangles);
+		BVHNode(BoundingBox3D bbox, std::vector<Triangle> triangles);
 		BVHNode(const BVHNode& other);
 		~BVHNode();
 		//public members
@@ -27,8 +25,8 @@ namespace MIndices
 
 		//Get functions
 		const BoundingBox3D& Box() const noexcept;
-		vector<Triangle> GetTriangles() const noexcept;
-		vector<TriangleEdge> GetEdges() const noexcept;
+		std::vector<Triangle> GetTriangles() const noexcept;
+		std::vector<TriangleEdge> GetEdges() const noexcept;
 		std::vector<Triangle>::iterator GetTriBegin();
 		std::vector<Triangle>::iterator GetTriEnd();
 		std::vector<TriangleEdge>::iterator GetEdgeBegin();
@@ -37,7 +35,7 @@ namespace MIndices
 
 		//Set functions
 		void SetBBox(const BoundingBox3D& newBBox);
-		void SetTriangles(const vector<Triangle>& triangles);
+		void SetTriangles(const std::vector<Triangle>& triangles);
 
 		void ClearTriangles();
 
@@ -45,8 +43,8 @@ namespace MIndices
 
 	private:
 		BoundingBox3D bbox;
-		vector<Triangle> triangles;
-		vector<TriangleEdge> edges;
+		std::vector<Triangle> triangles;
+		std::vector<TriangleEdge> edges;
 
 	};
 }

--- a/MIndices/BVHTree.cpp
+++ b/MIndices/BVHTree.cpp
@@ -90,7 +90,7 @@ BoundingBox3D BVHTree::ComputeBounds(const Triangle& triangle) const
 		static_cast<size_t>(maxPoint3D.z));
 }
 
-BoundingBox3D BVHTree::ComputeBounds(const vector<Triangle>& triangles) const
+BoundingBox3D BVHTree::ComputeBounds(const std::vector<Triangle>& triangles) const
 {
 	assert(triangles.size() > 0);
 	Point3D minTriPoint, maxTriPoint;
@@ -123,7 +123,7 @@ BoundingBox3D BVHTree::ComputeBounds(const vector<Triangle>& triangles) const
 		static_cast<size_t>(maxTriPoint.z));
 }
 
-void BVHTree::TopDownBuildObjectMedian(vector<Triangle>& triangles) noexcept
+void BVHTree::TopDownBuildObjectMedian(std::vector<Triangle>& triangles) noexcept
 {
 	if (triangles.size() > MAX_TRIANGLES_PER_LEAF)
 	{
@@ -137,7 +137,7 @@ void BVHTree::TopDownBuildObjectMedian(vector<Triangle>& triangles) noexcept
 		QuickSortTri(triangles, 0, (int32_t)triangles.size() - 1, longestAxis);
 
 		//PartitionArray
-		vector<Triangle> S1, S2;
+		std::vector<Triangle> S1, S2;
 		size_t k = PartitionSet(triangles, S1, S2);
 
 		BoundingBox3D lbox = ComputeBounds(S1);
@@ -156,7 +156,7 @@ void BVHTree::TopDownBuildObjectMedian(vector<Triangle>& triangles) noexcept
 	}
 }
 
-void BVHTree::TopDownBuildObjectMedian(BVHNode* pnode, vector<Triangle>& triangles) noexcept
+void BVHTree::TopDownBuildObjectMedian(BVHNode* pnode, std::vector<Triangle>& triangles) noexcept
 {
 	if (triangles.size() > MAX_TRIANGLES_PER_LEAF)
 	{
@@ -168,7 +168,7 @@ void BVHTree::TopDownBuildObjectMedian(BVHNode* pnode, vector<Triangle>& triangl
 		QuickSortTri(triangles, 0, (int32_t)triangles.size() - 1, longestAxis);
 
 		//PartitionArray into two sets
-		vector<Triangle> S1, S2;
+		std::vector<Triangle> S1, S2;
 		size_t k = PartitionSet(triangles, S1, S2);
 
 		//Compute left child bounding box
@@ -189,13 +189,13 @@ void BVHTree::TopDownBuildObjectMedian(BVHNode* pnode, vector<Triangle>& triangl
 	}
 }
 
-void BVHTree::BottomUpBuild(vector<Triangle>& triangles) noexcept
+void BVHTree::BottomUpBuild(std::vector<Triangle>& triangles) noexcept
 {
 	//ToDO implement bottom up hierarchy construction.
 }
 
 
-void BVHTree::TopDowwBuildObjectMedian_Parralel(vector<Triangle>& triangles) noexcept
+void BVHTree::TopDowwBuildObjectMedian_Parralel(std::vector<Triangle>& triangles) noexcept
 {
 	const int32_t NUM_OF_THRDS = 2;
 
@@ -211,7 +211,7 @@ void BVHTree::TopDowwBuildObjectMedian_Parralel(vector<Triangle>& triangles) noe
 		QuickSortTri(triangles, 0, (int32_t)triangles.size() - 1, longestAxis);
 
 		//PartitionArray
-		vector<Triangle> S1, S2;
+		std::vector<Triangle> S1, S2;
 		size_t k = PartitionSet(triangles, S1, S2);
 
 		BoundingBox3D lbox = ComputeBounds(S1);
@@ -255,7 +255,7 @@ void BVHTree::TopDowwBuildObjectMedian_Parralel(vector<Triangle>& triangles) noe
 }
 
 //Partitions set of triangles in two sets using the median Point of the set
-size_t BVHTree::PartitionSet(const vector<Triangle>& triangles, vector<Triangle>& S1, vector<Triangle>& S2) const
+size_t BVHTree::PartitionSet(const std::vector<Triangle>& triangles, std::vector<Triangle>& S1, std::vector<Triangle>& S2) const
 {
 	//Split the object at the object median of the longest axis
 	size_t median = static_cast<size_t>(triangles.size() * (COORD_TYPE)0.5);
@@ -288,7 +288,7 @@ Axis BVHTree::FindLongestAxisOfBBox(const BoundingBox3D& box) const noexcept
 }
 
 //Copies triangles to subarray at the median of the original array
-void BVHTree::CopyTriangles(vector<Triangle>& triDest, const vector<Triangle>& triSource, size_t indx_start, size_t indx_end) const noexcept
+void BVHTree::CopyTriangles(std::vector<Triangle>& triDest, const std::vector<Triangle>& triSource, size_t indx_start, size_t indx_end) const noexcept
 {
 	assert(triSource.size() > 0);
 
@@ -329,7 +329,7 @@ float BVHTree::CalculateSurfaceAreaOfBox(const BoundingBox3D& box) const noexcep
 }
 
 //Quick Sort Algorithm
-void BVHTree::QuickSortTri(vector<Triangle>& tri, int32_t lo, int32_t hi, Axis axis) noexcept
+void BVHTree::QuickSortTri(std::vector<Triangle>& tri, int32_t lo, int32_t hi, Axis axis) noexcept
 {
 	if (lo < hi)
 	{
@@ -359,7 +359,7 @@ COORD_TYPE MIndices::BVHTree::SelectPointAxis(const Point3D& p, Axis axis) noexc
 }
 
 //Partitions set using the centroid of the triangles along the x axis
-int32_t BVHTree::partitionTriXAxis(vector<Triangle>& tri, int32_t lo, int32_t hi) noexcept
+int32_t BVHTree::partitionTriXAxis(std::vector<Triangle>& tri, int32_t lo, int32_t hi) noexcept
 {
 	int32_t pivot_ind = lo;
 	int32_t i = lo - 1;
@@ -390,7 +390,7 @@ int32_t BVHTree::partitionTriXAxis(vector<Triangle>& tri, int32_t lo, int32_t hi
 }
 
 //Partitions set using the centroid of the triangles along the y axis
-int32_t BVHTree::partitionTriYAxis(vector<Triangle>& tri, int32_t lo, int32_t hi) noexcept
+int32_t BVHTree::partitionTriYAxis(std::vector<Triangle>& tri, int32_t lo, int32_t hi) noexcept
 {
 	size_t pivot_ind = lo;
 	int32_t i = lo - 1;
@@ -422,7 +422,7 @@ int32_t BVHTree::partitionTriYAxis(vector<Triangle>& tri, int32_t lo, int32_t hi
 }
 
 //Partitions set using the centroid of the triangles along the z axis
-int32_t BVHTree::partitionTriZAxis(vector<Triangle>& tri, int32_t lo, int32_t hi) noexcept
+int32_t BVHTree::partitionTriZAxis(std::vector<Triangle>& tri, int32_t lo, int32_t hi) noexcept
 {
 	size_t pivot_ind = lo;
 	int32_t i = lo - 1;
@@ -452,7 +452,7 @@ int32_t BVHTree::partitionTriZAxis(vector<Triangle>& tri, int32_t lo, int32_t hi
 	return 0;
 }
 //Traverse the tree using DFS and check for any intersections with the ray
-void BVHTree::RayTraceNodes(BVHNode* node, const Ray& r, vector<Point3D>& outpoints) const noexcept
+void BVHTree::RayTraceNodes(BVHNode* node, const Ray& r, std::vector<Point3D>& outpoints) const noexcept
 {
 	if (node == nullptr)
 	{
@@ -480,7 +480,7 @@ void BVHTree::RayTraceNodes(BVHNode* node, const Ray& r, vector<Point3D>& outpoi
 	}
 }
 
-void BVHTree::RayTraceNodesPreEdges(BVHNode* node, const Ray& r, vector<Point3D>& outpoints, vector<double>& outT) const noexcept
+void BVHTree::RayTraceNodesPreEdges(BVHNode* node, const Ray& r, std::vector<Point3D>& outpoints, std::vector<double>& outT) const noexcept
 {
 	if (node == nullptr)
 	{
@@ -493,7 +493,7 @@ void BVHTree::RayTraceNodesPreEdges(BVHNode* node, const Ray& r, vector<Point3D>
 		{
 			if (node->HasComputedEdges())
 			{
-				for (vector<TriangleEdge>::iterator it = node->GetEdgeBegin(); it != node->GetEdgeEnd(); ++it)
+				for (std::vector<TriangleEdge>::iterator it = node->GetEdgeBegin(); it != node->GetEdgeEnd(); ++it)
 				{
 					Point3D tmp_Point;
 					double tmp_t;

--- a/MIndices/BVHTree.h
+++ b/MIndices/BVHTree.h
@@ -10,8 +10,6 @@
 #include <assert.h>
 #include <omp.h>
 
-using std::vector;
-
 namespace MIndices
 {
 	constexpr uint32_t MAX_TRIANGLES_PER_LEAF = 1;
@@ -24,14 +22,14 @@ namespace MIndices
 
 		//Hierarchy construction functions
 		//Top-down build methods using standard recursion
-		void TopDownBuildObjectMedian(vector<Triangle>& triangles) noexcept;
-		void TopDowwBuildObjectMedian_Parralel(vector<Triangle>& triangles) noexcept;
+		void TopDownBuildObjectMedian(std::vector<Triangle>& triangles) noexcept;
+		void TopDowwBuildObjectMedian_Parralel(std::vector<Triangle>& triangles) noexcept;
 
 		//Bottom-up build methods
-		void BottomUpBuild(vector<Triangle>& triangles) noexcept;	//ToDo implementation missing
+		void BottomUpBuild(std::vector<Triangle>& triangles) noexcept;	//ToDo implementation missing
 
 		//Compute bounds functions
-		BoundingBox3D ComputeBounds(const vector<Triangle>& triangles) const;
+		BoundingBox3D ComputeBounds(const std::vector<Triangle>& triangles) const;
 		BoundingBox3D ComputeBounds(const Triangle& triangle) const;
 
 		//utility functions
@@ -39,11 +37,11 @@ namespace MIndices
 		int32_t FindDepth(BVHNode* node) const noexcept;
 		bool TreeIsEmpty() const noexcept;
 		Axis FindLongestAxisOfBBox(const BoundingBox3D& box) const noexcept;
-		void CopyTriangles(vector<Triangle>& triDest, const vector<Triangle>& triOrig, size_t start, size_t end) const noexcept;
+		void CopyTriangles(std::vector<Triangle>& triDest, const std::vector<Triangle>& triOrig, size_t start, size_t end) const noexcept;
 
 		//traversal functions
-		void RayTraceNodes(BVHNode* node, const Ray& r, vector<Point3D>& outpoints) const noexcept;
-		void RayTraceNodesPreEdges(BVHNode* node, const Ray& r, vector<Point3D>& outpoints, vector<double>& outT) const noexcept;	//ToDO unused method
+		void RayTraceNodes(BVHNode* node, const Ray& r, std::vector<Point3D>& outpoints) const noexcept;
+		void RayTraceNodesPreEdges(BVHNode* node, const Ray& r, std::vector<Point3D>& outpoints, std::vector<double>& outT) const noexcept;	//ToDO unused method
 		void DFSTraverse(BVHNode* node, int32_t& visitedNodes, int32_t& visitedLeafs) const noexcept;
 		void PrecomputeEdges(BVHNode* node, int32_t& out);	//ToDO unused method
 
@@ -57,17 +55,17 @@ namespace MIndices
 
 		//Hierarchy construction functions
 		//Top-down build methods using standard recursion
-		void TopDownBuildObjectMedian(BVHNode* pnode, vector<Triangle>& triangles) noexcept;
+		void TopDownBuildObjectMedian(BVHNode* pnode, std::vector<Triangle>& triangles) noexcept;
 
 		//Partitions a vector of triangles into 2 sets
-		size_t PartitionSet(const vector<Triangle>& triangles, vector<Triangle>& S1, vector<Triangle>& S2) const;
+		size_t PartitionSet(const std::vector<Triangle>& triangles, std::vector<Triangle>& S1, std::vector<Triangle>& S2) const;
 
 		//sorting functions
-		void QuickSortTri(vector<Triangle>& tri, int32_t lo, int32_t hi, Axis axis) noexcept;
+		void QuickSortTri(std::vector<Triangle>& tri, int32_t lo, int32_t hi, Axis axis) noexcept;
 		COORD_TYPE SelectPointAxis(const Point3D& p, Axis axis) noexcept;
-		int32_t partitionTriXAxis(vector<Triangle>& tri, int32_t lo, int32_t hi) noexcept;
-		int32_t partitionTriYAxis(vector<Triangle>& tri, int32_t lo, int32_t hi) noexcept;
-		int32_t partitionTriZAxis(vector<Triangle>& tri, int32_t lo, int32_t hi) noexcept;
+		int32_t partitionTriXAxis(std::vector<Triangle>& tri, int32_t lo, int32_t hi) noexcept;
+		int32_t partitionTriYAxis(std::vector<Triangle>& tri, int32_t lo, int32_t hi) noexcept;
+		int32_t partitionTriZAxis(std::vector<Triangle>& tri, int32_t lo, int32_t hi) noexcept;
 
 		//Compute centroid functions
 		Point3D ComputeCentroidOfTriangle(const Triangle& t) const noexcept;

--- a/MIndices/MIndice.h
+++ b/MIndices/MIndice.h
@@ -3,11 +3,13 @@
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
+#include <mutex>
 #include <iterator>
 #include <omp.h>
 #include <chrono>
 
 //custom headers
+#include "Structures.h"
 #include "Vector3D.h"
 #include "Array3D.h"
 #include "MarchingCubes.h"
@@ -15,7 +17,6 @@
 #include "RayGrid.h"
 #include "BVHTree.h"
 #include "AnglePair.h"
-#include "Structures.h"
 #include "IFileIOHandler.h"
 
 namespace MIndices
@@ -37,7 +38,7 @@ namespace MIndices
 	class MIndice
 	{
 	public:
-		MIndice(size_t dim_x, size_t dim_y, size_t dim_z, IFileIOHandler& fileIOHandler);
+		MIndice(size_t dim_x, size_t dim_y, size_t dim_z, IFileIOHandler& fileIOHandler, ParallelThreads threadOpts = ParallelThreads::off);
 		MIndice(const MIndice& other) = delete;
 		~MIndice() = default;
 
@@ -52,6 +53,7 @@ namespace MIndices
 		int32_t ComputeIndice();
 	private:
 		int32_t RayTraceBVHNodes(std::vector<VecPoint3D>& outPoints);
+		int32_t RayTraceBVHNodes(std::vector<VecPoint3D>& outPoints, const std::vector<Ray>& rays);
 		std::unique_ptr<Vector3D> vector3D;
 		std::vector<Triangle> triArr;
 		std::vector<AnglePair> pairs;
@@ -61,10 +63,15 @@ namespace MIndices
 		std::unique_ptr<BVHTree> bvh;
 		size_t dim_x, dim_y, dim_z;
 
+		ParallelThreads threadOpts = ParallelThreads::off;
+		std::mutex mutex;
 		InitState state = InitState::initial;
 		bool IsValidState(InitState expected) const;
 		static const std::unordered_map<InitState, std::unordered_set<InitState>> stateMap;
 		void UpdateState(const InitState newState, std::string&& func_name);
+
+		int32_t ComputeIndiceDefault();
+		int32_t ComputeIndiceParallel();
 	};
 
 }

--- a/MIndices/MIndices.vcxproj
+++ b/MIndices/MIndices.vcxproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ClCompile Include="AnglePair.cpp" />
     <ClCompile Include="CmdParser.cpp" />
+    <ClCompile Include="ThreadPool.cpp" />
     <ClCompile Include="Vector3D.cpp" />
     <ClCompile Include="BVHNode.cpp" />
     <ClCompile Include="BVHTree.cpp" />
@@ -34,6 +35,7 @@
   <ItemGroup>
     <ClInclude Include="AnglePair.h" />
     <ClInclude Include="CmdParser.h" />
+    <ClInclude Include="ThreadPool.h" />
     <ClInclude Include="Vector3D.h" />
     <ClInclude Include="Array3D.h" />
     <ClInclude Include="BoundingBox.h" />

--- a/MIndices/MIndices.vcxproj.filters
+++ b/MIndices/MIndices.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClCompile Include="CmdParser.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ThreadPool.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BoundingBox.h">
@@ -93,6 +96,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="CmdParser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ThreadPool.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/MIndices/Main.cpp
+++ b/MIndices/Main.cpp
@@ -19,8 +19,8 @@
 #include "BVHTree.h"
 #include "MIndice.h"
 #include "FileIOHandler.h"
-#include "AnglePair.h"
 #include "CmdParser.h"
+#include "AnglePair.h"
 
 using std::vector;
 using namespace MIndices;
@@ -65,7 +65,7 @@ int32_t main(int32_t argc, char* argv[])
 	const std::string outFilename = filename.substr(indx + 1, filename.length() - 3).append("_Pairs-New.txt");
 
 	FileIOHandler fileHandler;
-	std::unique_ptr<MIndice> indices = std::make_unique<MIndice>(DimX, DimY, DimZ, fileHandler);
+	std::unique_ptr<MIndice> indices = std::make_unique<MIndice>(DimX, DimY, DimZ, fileHandler, parser.Threads());
 	try
 	{
 		indices->Init(filename);

--- a/MIndices/MarchingCubes.cpp
+++ b/MIndices/MarchingCubes.cpp
@@ -338,7 +338,7 @@ inline Point3D MarchingCubes::FindEdgeMidPoint(const Point3D& p1, const Point3D&
 }
 
 //Prints triangles to a file
-bool MarchingCubes::PrintTrianglesToFile(const vector<Triangle>& vecTriangles, const std::string& fPath)
+bool MarchingCubes::PrintTrianglesToFile(const std::vector<Triangle>& vecTriangles, const std::string& fPath)
 {
 	int32_t triCounter = 0;
 	std::ofstream file(fPath, std::ios::out | std::ios::app);
@@ -366,7 +366,7 @@ bool MarchingCubes::PrintTrianglesToFile(const vector<Triangle>& vecTriangles, c
 }
 
 //Prints triangles to a file using a buffer
-bool MarchingCubes::PrintTrianglesToFile(const vector<Triangle>& vecTriangles, const size_t bufferSize, const std::string& fPath)
+bool MarchingCubes::PrintTrianglesToFile(const std::vector<Triangle>& vecTriangles, const size_t bufferSize, const std::string& fPath)
 {
 	int32_t triCounter = 0;
 	std::ofstream file(fPath, std::ios::out | std::ios::app);
@@ -407,7 +407,7 @@ bool MarchingCubes::PrintTrianglesToFile(const vector<Triangle>& vecTriangles, c
 	}
 }
 
-bool MarchingCubes::SaveToFile(const vector<Triangle>& triangles, const char* FileSpec) const
+bool MarchingCubes::SaveToFile(const std::vector<Triangle>& triangles, const char* FileSpec) const
 {
 	FILE* file = (FILE*)fopen(FileSpec, "w+");
 	if (file == nullptr)

--- a/MIndices/MarchingCubes.h
+++ b/MIndices/MarchingCubes.h
@@ -12,8 +12,6 @@
 #include "Array3D.h"
 #include "Vector3D.h"
 
-using std::vector;
-
 namespace MIndices
 {
 
@@ -321,15 +319,15 @@ namespace MIndices
 
 		//Printing functions
 		bool PrintCubesToFile(const std::string& fPath);
-		bool PrintTrianglesToFile(const vector<Triangle>& vecTriangles, const std::string& fPath);
-		bool PrintTrianglesToFile(const vector<Triangle>& vecTriangles, const size_t bufferSize, const std::string& fPath);
+		bool PrintTrianglesToFile(const std::vector<Triangle>& vecTriangles, const std::string& fPath);
+		bool PrintTrianglesToFile(const std::vector<Triangle>& vecTriangles, const size_t bufferSize, const std::string& fPath);
 
 		//save to file
-		bool SaveToFile(const vector<Triangle>& triangles, const char* FileSpec) const;
+		bool SaveToFile(const std::vector<Triangle>&triangles, const char* FileSpec) const;
 
 	private:
-		vector<MCube> cubes;
-		vector<VoxelCube> vCubes;
+		std::vector<MCube> cubes;
+		std::vector<VoxelCube> vCubes;
 
 		inline bool CubeInOutSurface(const MCube& cube, int32_t& cubeindex) const noexcept;
 		inline bool CubeInOutSurface(const VoxelCube& cube, int32_t& cubeindex) const noexcept;

--- a/MIndices/MarchingCubes.h
+++ b/MIndices/MarchingCubes.h
@@ -2,8 +2,6 @@
 //MarchingCubes.h
 //Lookup table by Paul Boorke http://paulbourke.net/geometry/polygonise/
 #pragma once
-#ifndef Cubes_H
-#define Cubes_H
 
 #include <string>
 #include <vector>
@@ -339,4 +337,3 @@ namespace MIndices
 		inline Point3D FindEdgeMidPoint(const Point3D& p1, const Point3D& p2) const noexcept;
 	};
 }
-#endif  Cubes_H

--- a/MIndices/Ray.h
+++ b/MIndices/Ray.h
@@ -11,6 +11,7 @@ namespace MIndices
 	constexpr double RAD = PI / 180;
 	constexpr double EPSILON = 0.0000001;
 	constexpr COORD_TYPE numeric_epsilon = std::numeric_limits<COORD_TYPE>::epsilon();
+	constexpr double DEGREE = 1.0;
 
 	class Ray
 	{

--- a/MIndices/Ray.h
+++ b/MIndices/Ray.h
@@ -12,6 +12,8 @@ namespace MIndices
 	constexpr double EPSILON = 0.0000001;
 	constexpr COORD_TYPE numeric_epsilon = std::numeric_limits<COORD_TYPE>::epsilon();
 	constexpr double DEGREE = 1.0;
+	constexpr int32_t ELEVATION = 90;
+	constexpr int32_t AZIMUTH = 180;
 
 	class Ray
 	{

--- a/MIndices/RayGrid.cpp
+++ b/MIndices/RayGrid.cpp
@@ -31,6 +31,23 @@ void RayGrid::RotateRays(double d, Axis axis)
 	}
 }
 
+//Computes the rotational grid for all rays for given elevation & azimuth pairs.
+//@param value of elevation to rotate the rays
+//@param value of azimuth to rotate the rays
+RotationGrid MIndices::RayGrid::ComputeRotationGrid(int32_t elevation, int32_t azimuth)
+{
+	RotationGrid rotationGrid;
+	for (int i = 0; i < elevation; ++i)
+	{
+		for (int32_t j = 0; j < azimuth; ++j)
+		{
+			RotateRays(DEGREE, Axis::X, i, j, rotationGrid);
+		}
+		RotateRays(DEGREE, Axis::Z, i, 0, rotationGrid);
+	}
+	return rotationGrid;
+}
+
 const std::vector<Ray>& MIndices::RayGrid::getRays() const noexcept
 {
 	return rays;
@@ -44,4 +61,14 @@ std::span<const Ray> MIndices::RayGrid::getRaySpan() const noexcept
 const bool MIndices::RayGrid::empty() const noexcept
 {
 	return rays.empty();
+}
+
+void MIndices::RayGrid::RotateRays(double d, Axis axis, int32_t elevation, int32_t azimuth, RotationGrid& rotationGrid)
+{
+	auto tmp_rays = rays;
+	for (auto& ray : tmp_rays)
+	{
+		ray.Rotate(d, Axis::X);
+	}
+	rotationGrid.emplace_back(AzthElevPair{elevation, azimuth}, std::move(tmp_rays));
 }

--- a/MIndices/RayGrid.cpp
+++ b/MIndices/RayGrid.cpp
@@ -48,6 +48,16 @@ RotationGrid MIndices::RayGrid::ComputeRotationGrid(int32_t elevation, int32_t a
 	return rotationGrid;
 }
 
+std::span<const std::vector<Ray>> MIndices::RayGrid::ComputeAzimuthRays(int32_t steps)
+{
+	for (int32_t i = 0; i < steps; ++i)
+	{
+		RotateRays(DEGREE, Axis::Z);
+		azimuthRays[i] = rays;
+	}
+	return azimuthRays;
+}
+
 const std::vector<Ray>& MIndices::RayGrid::getRays() const noexcept
 {
 	return rays;

--- a/MIndices/RayGrid.h
+++ b/MIndices/RayGrid.h
@@ -6,8 +6,7 @@
 
 namespace MIndices
 {
-	constexpr double DEGREE = 1.0;
-
+	using RotationGrid = std::vector<std::pair<AzthElevPair, std::vector<Ray>>>;
 	//Creates an array of rays of X * Y size
 	class RayGrid
 	{
@@ -17,11 +16,13 @@ namespace MIndices
 		RayGrid(size_t DimX, size_t DimY, size_t diagonal);
 
 		void RotateRays(double d, Axis axis);
+		RotationGrid ComputeRotationGrid(int32_t elevation, int32_t azimuth);
 		const std::vector<Ray> &getRays() const noexcept;
 		std::span<const Ray> getRaySpan() const noexcept;
 		const bool empty() const noexcept;
 	private:
 		std::vector<Ray> rays;
+		void RotateRays(double d, Axis axis, int32_t elevation, int32_t azimuth, RotationGrid& rotationGrid);
 	};
 
 }

--- a/MIndices/RayGrid.h
+++ b/MIndices/RayGrid.h
@@ -17,11 +17,13 @@ namespace MIndices
 
 		void RotateRays(double d, Axis axis);
 		RotationGrid ComputeRotationGrid(int32_t elevation, int32_t azimuth);
+		std::span<const std::vector<Ray>> ComputeAzimuthRays(int32_t steps = AZIMUTH);
 		const std::vector<Ray> &getRays() const noexcept;
 		std::span<const Ray> getRaySpan() const noexcept;
 		const bool empty() const noexcept;
 	private:
 		std::vector<Ray> rays;
+		std::array<std::vector<Ray>, AZIMUTH> azimuthRays;
 		void RotateRays(double d, Axis axis, int32_t elevation, int32_t azimuth, RotationGrid& rotationGrid);
 	};
 

--- a/MIndices/Structures.h
+++ b/MIndices/Structures.h
@@ -134,4 +134,6 @@ namespace MIndices
 	}TriangleEdge;
 
 	using VecPoint3D = std::vector<Point3D>;
+
+	using AzthElevPair = std::pair<int32_t, int32_t>;
 }

--- a/MIndices/Structures.h
+++ b/MIndices/Structures.h
@@ -2,6 +2,8 @@
 #pragma once
 
 #include <vector>
+#include <array>
+#include <thread>
 
 namespace MIndices
 {
@@ -21,7 +23,24 @@ namespace MIndices
 		count			// 8 - keep count of enums
 	};
 
-	enum class Axis { X, Y, Z };
+	const std::array<uint32_t, static_cast<int32_t>(ParallelThreads::count)> threadMap =
+	{
+		0u,													// 0 - off
+		std::thread::hardware_concurrency(),				// 1 - enabled auto
+		2u,													// 2 - enabled 2 threads
+		4u,													// 3 - enabled 4 threads
+		6u,													// 4 - enabled 6 threads
+		8u,													// 5 - enabled 8 threads
+		10u,												// 6 - enabled 10 threads
+		12u													// 7 - enabled 12 threads
+	};
+
+	enum class Axis 
+	{
+		X,
+		Y,
+		Z
+	};
 
 	enum class ElementTypes : uint8_t
 	{

--- a/MIndices/ThreadPool.cpp
+++ b/MIndices/ThreadPool.cpp
@@ -1,0 +1,67 @@
+#include "ThreadPool.h"
+
+ThreadPool::ThreadPool(MIndices::ParallelThreads threadOpts)
+{
+	if (threadOpts != MIndices::ParallelThreads::off)
+	{
+		uint32_t numThreads = MIndices::threadMap[static_cast<uint32_t>(threadOpts)];
+		for (uint32_t i = 0; i < numThreads; ++i)
+		{
+			threads.emplace_back([this]()
+				{
+					StartThreads();
+				});
+		}
+	}
+	else
+	{
+		throw std::runtime_error("Failed to intialize Thread Pool, invalid number of threads passed.");
+	}
+
+}
+
+ThreadPool::~ThreadPool()
+{
+	stop = true;
+	condition.notify_all();
+	for (auto& thread : threads)
+	{
+		thread.join();
+	}
+}
+
+void ThreadPool::EnqueTask(std::function<void()> task)
+{
+	if (tasks.size() >= maxQueueSize)
+	{
+		throw std::runtime_error("Tasks queue already at maximum size.");
+	}
+
+	std::unique_lock<std::mutex> lock(mutex);
+	tasks.push_back(std::move(task));
+	condition.notify_one();
+}
+
+void ThreadPool::StartThreads()
+{
+	while (true)
+	{
+		std::function<void()> task;
+		{
+			std::unique_lock<std::mutex> lock(mutex);
+			condition.wait(lock, [this]()
+				{
+					return stop || !tasks.empty();
+				});
+
+			if (stop && tasks.empty())
+			{
+				return;
+			}
+
+			task = std::move(tasks.front());
+			tasks.pop_front();
+		}
+		task();
+	}
+}

--- a/MIndices/ThreadPool.h
+++ b/MIndices/ThreadPool.h
@@ -12,7 +12,7 @@ class ThreadPool
 {
 public:
 	ThreadPool() = default;
-	ThreadPool(MIndices::ParallelThreads threadOpts);
+	ThreadPool(MIndices::ParallelThreads threadOpts, size_t quueSize);
 	~ThreadPool();
 
 	void EnqueTask(std::function<void()> task);
@@ -22,9 +22,7 @@ private:
 	std::condition_variable condition;
 	std::mutex mutex;
 	std::atomic_bool stop = false;
-	const int32_t maxQueueSize = 10648;
+	size_t maxQueueSize;
 
 	void StartThreads();
 };
-
-	

--- a/MIndices/ThreadPool.h
+++ b/MIndices/ThreadPool.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <thread>
+#include <mutex>
+#include <vector>
+#include <memory>
+#include <deque>
+#include <functional>
+
+#include "Structures.h"
+
+class ThreadPool
+{
+public:
+	ThreadPool() = default;
+	ThreadPool(MIndices::ParallelThreads threadOpts);
+	~ThreadPool();
+
+	void EnqueTask(std::function<void()> task);
+private:
+	std::vector<std::thread> threads;
+	std::deque<std::function<void()>> tasks;
+	std::condition_variable condition;
+	std::mutex mutex;
+	std::atomic_bool stop = false;
+	const int32_t maxQueueSize = 10648;
+
+	void StartThreads();
+};
+
+	


### PR DESCRIPTION
Updated MIndices implementation to utilize a thread pool of std threads. The pool supports enqueuing and consumption of tasks, utilized for the parallel implementation of indice computation. Additional extensions were implemented to precomputed all rays across azimuth angles for independent thread execution.